### PR TITLE
Configure Homebrew tap trust

### DIFF
--- a/dot/shrc
+++ b/dot/shrc
@@ -26,6 +26,7 @@ if [ -x /opt/homebrew/bin/brew ]; then
 	export HOMEBREW_NO_AUTO_UPDATE=1
 	export HOMEBREW_NO_INSTALL_CLEANUP=1
 	export HOMEBREW_NO_EMOJI=1
+	export HOMEBREW_REQUIRE_TAP_TRUST=1
 fi
 
 if command -v gpg >/dev/null 2>&1; then

--- a/script/setup_homebrew_trust
+++ b/script/setup_homebrew_trust
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+set -eu
+
+DOTFILES="${DOTFILES:-$HOME/.dotfiles}"
+BREWFILE="$DOTFILES/dot/Brewfile"
+
+if ! command -v brew >/dev/null 2>&1; then
+	echo "setup_homebrew_trust: brew not found, skipping"
+	exit 0
+fi
+
+if [ ! -f "$BREWFILE" ]; then
+	echo "setup_homebrew_trust: Brewfile not found at $BREWFILE, skipping" >&2
+	exit 0
+fi
+
+brew bundle list --file "$BREWFILE" --tap |
+	while IFS= read -r tap; do
+		[ -n "$tap" ] || continue
+		brew trust --tap "$tap"
+	done
+
+echo "setup_homebrew_trust: trusted Brewfile taps"

--- a/script/strap-after-setup
+++ b/script/strap-after-setup
@@ -3,6 +3,7 @@ set -eu
 
 # Stuff to happen after brew is installed goes here!
 
+~/.dotfiles/script/setup_homebrew_trust
 ~/.dotfiles/script/disable_chime
 ~/.dotfiles/script/setup_default_apps
 ~/.dotfiles/script/setup_dock


### PR DESCRIPTION
## Summary
- Enable Homebrew tap trust checks in shell configuration.
- Add a setup script that trusts taps declared in the Brewfile.
- Run the trust setup during post-Homebrew bootstrap.

## Test plan
- `sh -n script/setup_homebrew_trust script/strap-after-setup dot/shrc`
- `HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_FROM_API=1 brew bundle list --file dot/Brewfile --tap`
- `script/setup_homebrew_trust && HOMEBREW_NO_AUTO_UPDATE=1 brew trust`


Made with [Cursor](https://cursor.com)