### PR TITLE
Fix gprune for linked worktree branches

### DIFF
--- a/script/aliases
+++ b/script/aliases
@@ -83,8 +83,10 @@ gprune() {
 	git branch --remotes \
 		| awk '{print $1}' \
 		| grep -E -v -f /dev/fd/0 <(git branch -vv | grep origin) \
-		| awk '{print $1}' \
-		| xargs git branch -D
+		| awk '$1 != "*" && $1 != "+" {print $1}' \
+		| while IFS= read -r branch; do
+			git branch -D -- "$branch"
+		done
 }
 
 alias lzd="lazydocker"


### PR DESCRIPTION
## Summary
- ignore `*` and `+` markers emitted by `git branch -vv` so linked-worktree branches are not treated as branch names
- read candidates in a guarded loop so an empty result does not invoke `git branch -D`

## Test plan
- [x] `zsh -n script/aliases`
- [x] Simulated stale, current, and linked-worktree branch output; only the ordinary stale branch was selected

Made with [Cursor](https://cursor.com)